### PR TITLE
fix: included AvaloniaEdit styles for Markdown code blocks

### DIFF
--- a/LiveMarkdown/Themes/Generic.axaml
+++ b/LiveMarkdown/Themes/Generic.axaml
@@ -4,6 +4,9 @@
         xmlns:edit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
         xmlns:math="clr-namespace:AvaloniaMath.Controls;assembly=AvaloniaMath">
 
+    <!-- For AvaloniaEdit Styles -->
+    <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
+
     <!-- Template for MarkdownView -->
     <Style Selector="local|MarkdownView">
         <Setter Property="Template">


### PR DESCRIPTION
### Problem
`TextEditor` based code blocks were not rendering correctly (empty content, missing styling).

This happened because `AvaloniaEdit` styles were not included, which are required for proper rendering and layout.

I was able to fix this by including the required styling for AvaloniaEdit